### PR TITLE
Fix auth/webhook on Linux #38

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ I know there are credentials in this repo. They will all be hidden as soon as th
 
 Make sure you have Docker, docker-compose, and yarn installed. Links/instructions coming soon.
 
+**Note:** If you are on Linux environnement, copy ```scripts/docker_host.sh``` to ```/etc/profile.d/``` and log out from your current session.
+
 ## Install command line tools and dependencies necessary for development
     make install
 
 ## Start docker containers in one terminal where you can see the logs
     make cleardb
-    docker-compose up
+    make docker
 
 ## Setup everything; be mindful of startup times
     make setup_migrations

--- a/client/src/pages/Landing/LandingLoggedIn.vue
+++ b/client/src/pages/Landing/LandingLoggedIn.vue
@@ -62,7 +62,7 @@ export default {
         query: gql`
           query GetProjectsByUserId($userId: Int!) {
             assets(
-              where: {permissionset: {permissions: {group: {groups_users: {user_id: {_eq: $userId}}}}}},
+              where: {asset_type: {_eq: project}, _and: {created_by_id: {_eq: 1}}}
               order_by: {datetime_created: desc}
             ) {
               id

--- a/docker-compose.gnu.yml
+++ b/docker-compose.gnu.yml
@@ -24,7 +24,7 @@ services:
       HASURA_GRAPHQL_DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:${POSTGRES_PORT}/${HASURA_DATABASE}
       HASURA_GRAPHQL_ENABLE_CONSOLE: ${HASURA_ENABLE_CONSOLE}
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
-      HASURA_GRAPHQL_AUTH_HOOK: http://host.docker.internal:8000/${HASURA_WEBHOOK}
+      HASURA_GRAPHQL_AUTH_HOOK: http://${DOCKER_HOST_IP}:8000/${HASURA_WEBHOOK}
 
   minio:
     image: minio/minio:RELEASE.2019-10-12T01-39-57Z

--- a/scripts/docker_host.sh
+++ b/scripts/docker_host.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+DOCKER_HOST_IP='host.docker.internal'
+
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    DOCKER_HOST_IP=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
+fi
+
+export DOCKER_HOST_IP=${DOCKER_HOST_IP}

--- a/server/src/routes/hasura.ts
+++ b/server/src/routes/hasura.ts
@@ -5,7 +5,6 @@ export function routes (app: any, sessionStore: any) {
     (req: express.Request, res: express.Response) => {
       const sessionId = req.get('sessionID')
       sessionStore.get(sessionId, (err, data) => {
-        console.log(sessionId, data)
         if (data.dbId) {
           res.json({
             'X-Hasura-Admin-Secret': 'mysecret',


### PR DESCRIPTION
The Docker Host IP address on Linux is different than Mac and Windows See link: https://nickjanetakis.com/blog/docker-tip-65-get-your-docker-hosts-ip-address-from-in-a-container.
To keep docker compose running on all platforms, I created a docker-compose.gnu.yml that will fetch an env variable created by the script docker_host.sh.
Also, added to the documentation how to set up docker_host.sh by copying it to /etc/profile.d/ folder and restarting the system, it needs to be done only once and will set DOCKER_HOST_IP address for all users which might not be a good practice but is fine for dev purposes.
@JeffSpies Important: I also changed the GetProjectByUserId gql query.