### PR TITLE
Add sanity checks for Minio uploads #37

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ I open 4 tabs and run the following commands
 Databrary: http://localhost:8000/login
 Hasura: http://localhost:8002 or http://localhost:9695
 Minio: http://localhost:9000
+
+# Important Notes:
+* Minio Client and Minio Docker image need to be compatible, make sure you alwauys have the right Minio Client for the right minio image.

--- a/client/.quasar/app.js
+++ b/client/.quasar/app.js
@@ -23,15 +23,17 @@ import createRouter from 'app/src/router/index'
 
 
 
-export default function () {
+
+
+export default async function () {
   // create store and router instances
   
   const store = typeof createStore === 'function'
-    ? createStore({Vue})
+    ? await createStore({Vue})
     : createStore
   
   const router = typeof createRouter === 'function'
-    ? createRouter({Vue, store})
+    ? await createRouter({Vue, store})
     : createRouter
   
   // make router instance available in store

--- a/client/.quasar/client-entry.js
+++ b/client/.quasar/client-entry.js
@@ -58,11 +58,13 @@ console.info('[Quasar] Running SPA.')
 
 
 
-const { app, store, router } = createApp()
-
 
 
 async function start () {
+  const { app, store, router } = await createApp()
+
+  
+
   
   let routeUnchanged = true
   const redirect = url => {
@@ -111,7 +113,7 @@ async function start () {
 
     
 
-      new Vue(app)
+    new Vue(app)
 
     
 

--- a/client/src/pages/Project/Upload.vue
+++ b/client/src/pages/Project/Upload.vue
@@ -40,6 +40,7 @@ export default {
             body: JSON.stringify({
               filename: file.name,
               contentType: file.type,
+              format: file.extension,
               projectId: that.projectIdFromRoute
             })
           }).then((response) => {
@@ -53,6 +54,8 @@ export default {
               fields: data.fields,
               headers: data.headers
             }
+          }).catch((error) => {
+            console.log(`Uppy error ${error}`)
           })
         }
       })

--- a/docker-compose.gnu.yml
+++ b/docker-compose.gnu.yml
@@ -37,6 +37,10 @@ services:
     environment:
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
+      MINIO_NOTIFY_WEBHOOK_ENABLE: "on"
+      MINIO_NOTIFY_WEBHOOK_ENDPOINT: http://${DOCKER_HOST_IP}:8000/webhooks/minio
+      MINIO_NOTIFY_WEBHOOK_QUEUE_DIR: "/events"
+      MINIO_NOTIFY_WEBHOOK_QUEUE_LIMIT: 10000
 
   # keycloak:
   #   image: jboss/keycloak

--- a/docker-compose.gnu.yml
+++ b/docker-compose.gnu.yml
@@ -27,7 +27,7 @@ services:
       HASURA_GRAPHQL_AUTH_HOOK: http://${DOCKER_HOST_IP}:8000/${HASURA_WEBHOOK}
 
   minio:
-    image: minio/minio:RELEASE.2019-10-12T01-39-57Z
+    image: minio/minio:RELEASE.2020-01-16T22-40-29Z
     volumes:
       - file_data:/data
       - minio_events:/events

--- a/docker-compose.gnu.yml
+++ b/docker-compose.gnu.yml
@@ -67,10 +67,6 @@ services:
   #   depends_on:
   #     - search
 
-
-
- 
-
 volumes:
   minio_events:
   postgres_data:

--- a/docker-compose.gnu.yml
+++ b/docker-compose.gnu.yml
@@ -27,7 +27,7 @@ services:
       HASURA_GRAPHQL_AUTH_HOOK: http://${DOCKER_HOST_IP}:8000/${HASURA_WEBHOOK}
 
   minio:
-    image: minio/minio:RELEASE.2020-01-16T22-40-29Z
+    image: minio/minio:RELEASE.2019-10-12T01-39-57Z
     volumes:
       - file_data:/data
       - minio_events:/events

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       HASURA_GRAPHQL_AUTH_HOOK: http://host.docker.internal:8000/${HASURA_WEBHOOK}
 
   minio:
-    image: minio/minio:RELEASE.2019-10-12T01-39-57Z
+    image: minio/minio:RELEASE.2020-01-16T22-40-29Z
     volumes:
       - file_data:/data
       - minio_events:/events

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       HASURA_GRAPHQL_AUTH_HOOK: http://host.docker.internal:8000/${HASURA_WEBHOOK}
 
   minio:
-    image: minio/minio:RELEASE.2020-01-16T22-40-29Z
+    image: minio/minio:RELEASE.2019-10-12T01-39-57Z
     volumes:
       - file_data:/data
       - minio_events:/events

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,10 @@ services:
     environment:
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
+      MINIO_NOTIFY_WEBHOOK_ENABLE: "on"
+      MINIO_NOTIFY_WEBHOOK_ENDPOINT: http://${DOCKER_HOST_IP}:8000/webhooks/minio
+      MINIO_NOTIFY_WEBHOOK_QUEUE_DIR: "/events"
+      MINIO_NOTIFY_WEBHOOK_QUEUE_LIMIT: 10000
 
   # keycloak:
   #   image: jboss/keycloak

--- a/gql/checkPermissionOfAsset.gql
+++ b/gql/checkPermissionOfAsset.gql
@@ -1,4 +1,4 @@
-query MyQuery ( $id: Int ) {
+query checkPermissionOfAsset ( $id: Int ) {
   assets(where: {id: {_eq: $id}}) {
     id
   }

--- a/gql/getFile.gql
+++ b/gql/getFile.gql
@@ -1,4 +1,4 @@
-query MyQuery ($id: Int){
+query getFile ($id: Int){
   files(
     where: {
       id: {
@@ -8,7 +8,7 @@ query MyQuery ($id: Int){
   ) {
     id
     name
-    uploaded_by_id
-    asset_id
+    uploadedById
+    assetId
   }
 }

--- a/gql/getFileObjectId.gql
+++ b/gql/getFileObjectId.gql
@@ -1,0 +1,11 @@
+query getFileObjectId ($sha256: String) {
+  fileobjects(
+      where: {
+        sha256: {
+         _eq: $sha256
+        }
+      }
+  ) {
+    id
+  }
+}

--- a/gql/getProjectPage.gql
+++ b/gql/getProjectPage.gql
@@ -1,4 +1,4 @@
-query MyQuery {
+query getProjectPage {
   assets(
     where: {
       asset_type: {

--- a/gql/insertFile.gql
+++ b/gql/insertFile.gql
@@ -1,13 +1,15 @@
 mutation ( 
   $name: String,
-  $uploaded_by_id: Int,
-  $asset_id: Int
+  $uploadedById: Int,
+  $assetId: Int,
+  $fileFormatId: fileformats_enum
 ) {
   insert_files(
     objects: { 
       name: $name,
-      uploaded_by_id: $uploaded_by_id,
-      asset_id: $asset_id
+      uploadedById: $uploadedById,
+      assetId: $assetId,
+      fileFormatId: $fileFormatId
     }
   ) {
     returning {

--- a/gql/insertFile.gql
+++ b/gql/insertFile.gql
@@ -1,8 +1,9 @@
+# TODO(Reda): change fileFormatID to fileformats_enum to restrict the format upload
 mutation ( 
   $name: String,
   $uploadedById: Int,
   $assetId: Int,
-  $fileFormatId: fileformats_enum
+  $fileFormatId: String
 ) {
   insert_files(
     objects: { 

--- a/gql/removeFile.gql
+++ b/gql/removeFile.gql
@@ -1,0 +1,7 @@
+mutation removeFile ($fileId: Int) {
+  delete_files(where: {id: {_eq: fileId}}) {
+    returning {
+      id
+    }
+  }
+}

--- a/gql/updateFile.gql
+++ b/gql/updateFile.gql
@@ -1,9 +1,9 @@
-mutation MyMutation ($fileobject_id: Int, $uploaded_datetime: Implicit) {
-  __typename
+mutation updateFile ($fileId: Int, $fileobjectId: Int, $uploadedDatetime: timestamp) {
   update_files(
+    where: {id: {_eq: $fileId}},
     _set: {
-      uploaded_datetime: $uploaded_datetime,
-      fileobject_id: $fileobject_id
+      fileobjectId: $fileobjectId,
+      uploadedDatetime: $uploadedDatetime
     }
   ) {
     returning {

--- a/hasura/migrations/1580317576800_create_table_public_fileformats/down.yaml
+++ b/hasura/migrations/1580317576800_create_table_public_fileformats/down.yaml
@@ -1,0 +1,3 @@
+- args:
+    sql: DROP TABLE "public"."fileformats"
+  type: run_sql

--- a/hasura/migrations/1580317576800_create_table_public_fileformats/up.yaml
+++ b/hasura/migrations/1580317576800_create_table_public_fileformats/up.yaml
@@ -1,0 +1,126 @@
+- args:
+    sql: CREATE TABLE "public"."fileformats"("id" text NOT NULL, "comment" text NOT
+      NULL, PRIMARY KEY ("id") ); COMMENT ON TABLE "public"."fileformats" IS E'Databrary
+      MIME Types';
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('csv', 'Comma-separated values');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('rtf', 'Rich Text format');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('png', 'Portable network graphics');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('pdf', 'Portable document');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('doc', 'Microsoft Word document');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('odf', 'OpenDocument text');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('docx', 'Microsoft Word (Office Open XML) document');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('xls', 'Microsoft Excel spreadsheet');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('ods', 'OpenDocument spreadsheet');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('xlsx', 'Microsoft Excel (Office Open XML) workbook');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('ppt', 'Microsoft PowerPoint presentation');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('odp', 'OpenDocument presentation');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('pptx', 'Microsoft PowerPoint (Office Open XML) presentation');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('opf', 'Datavyu');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('sav', 'SPSS System File');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('its', 'LENA Interpreted Time Segments');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('txt', 'Plain text');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('cha', 'Codes for the Human Analysis of Transcripts');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('chat', 'Codes for the Human Analysis of Transcripts');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('eaf', 'ELAN - Linguistic Annotator');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('pfsx', 'ELAN - Linguistic Annotator');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('etf', 'ELAN - Linguistic Annotator');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('jpg', 'JPEG image');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('jpeg', 'JPEG image');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('webm', 'WebM video');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('mpg', 'MPEG program stream (MPEG-1/MPEG-2 video)');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('mpeg', 'MPEG program stream (MPEG-1/MPEG-2 video)');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('mov', 'QuickTime video');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('mts', 'MPEG transport stream');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('m2ts', 'MPEG transport stream');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('avi', 'Audio Video Interleave');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('wmv', 'Windows Media video');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('dv', 'Digital Interface Format video');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('dif', 'Digital Interface Format video');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('mp4', 'MPEG-4 video');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('wav', 'Waveform audio');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('aac', 'Advanced Audio Coding');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('wma', 'Windows Media audio');
+  type: run_sql
+- args:
+    sql: INSERT INTO "public"."fileformats" VALUES ('mp3', 'MPEG-1 or MPEG-2 audio layer III');
+  type: run_sql
+- args:
+    name: fileformats
+    schema: public
+  type: add_existing_table_or_view

--- a/hasura/migrations/1580318261478_alter_table_public_fileformats_set_enum_true/down.yaml
+++ b/hasura/migrations/1580318261478_alter_table_public_fileformats_set_enum_true/down.yaml
@@ -1,0 +1,6 @@
+- args:
+    is_enum: false
+    table:
+      name: fileformats
+      schema: public
+  type: set_table_is_enum

--- a/hasura/migrations/1580318261478_alter_table_public_fileformats_set_enum_true/up.yaml
+++ b/hasura/migrations/1580318261478_alter_table_public_fileformats_set_enum_true/up.yaml
@@ -1,0 +1,6 @@
+- args:
+    is_enum: true
+    table:
+      name: fileformats
+      schema: public
+  type: set_table_is_enum

--- a/hasura/migrations/1580318358665_alter_table_public_files_add_column_fileFormatId/down.yaml
+++ b/hasura/migrations/1580318358665_alter_table_public_files_add_column_fileFormatId/down.yaml
@@ -1,0 +1,3 @@
+- args:
+    sql: ALTER TABLE "public"."files" DROP COLUMN "fileFormatId";
+  type: run_sql

--- a/hasura/migrations/1580318358665_alter_table_public_files_add_column_fileFormatId/up.yaml
+++ b/hasura/migrations/1580318358665_alter_table_public_files_add_column_fileFormatId/up.yaml
@@ -1,0 +1,3 @@
+- args:
+    sql: ALTER TABLE "public"."files" ADD COLUMN "fileFormatId" text NOT NULL;
+  type: run_sql

--- a/hasura/migrations/1580318370269_alter_table_public_files_alter_column_uploaded_datetime/down.yaml
+++ b/hasura/migrations/1580318370269_alter_table_public_files_alter_column_uploaded_datetime/down.yaml
@@ -1,0 +1,10 @@
+- args:
+    sql: ALTER TABLE "public"."files" ALTER COLUMN "uploaded_datetime" TYPE timestamp
+      without time zone;
+  type: run_sql
+- args:
+    sql: COMMENT ON COLUMN "public"."files"."uploaded_datetime" IS E'null'
+  type: run_sql
+- args:
+    sql: alter table "public"."files" rename column "uploadedDatetime" to "uploaded_datetime";
+  type: run_sql

--- a/hasura/migrations/1580318370269_alter_table_public_files_alter_column_uploaded_datetime/up.yaml
+++ b/hasura/migrations/1580318370269_alter_table_public_files_alter_column_uploaded_datetime/up.yaml
@@ -1,0 +1,9 @@
+- args:
+    sql: ALTER TABLE "public"."files" ALTER COLUMN "uploaded_datetime" TYPE timestamp;
+  type: run_sql
+- args:
+    sql: COMMENT ON COLUMN "public"."files"."uploaded_datetime" IS E''
+  type: run_sql
+- args:
+    sql: alter table "public"."files" rename column "uploaded_datetime" to "uploadedDatetime";
+  type: run_sql

--- a/hasura/migrations/1580318384752_alter_table_public_files_alter_column_asset_id/down.yaml
+++ b/hasura/migrations/1580318384752_alter_table_public_files_alter_column_asset_id/down.yaml
@@ -1,0 +1,9 @@
+- args:
+    sql: ALTER TABLE "public"."files" ALTER COLUMN "asset_id" TYPE integer;
+  type: run_sql
+- args:
+    sql: COMMENT ON COLUMN "public"."files"."asset_id" IS E'null'
+  type: run_sql
+- args:
+    sql: alter table "public"."files" rename column "assetId" to "asset_id";
+  type: run_sql

--- a/hasura/migrations/1580318384752_alter_table_public_files_alter_column_asset_id/up.yaml
+++ b/hasura/migrations/1580318384752_alter_table_public_files_alter_column_asset_id/up.yaml
@@ -1,0 +1,9 @@
+- args:
+    sql: ALTER TABLE "public"."files" ALTER COLUMN "asset_id" TYPE int4;
+  type: run_sql
+- args:
+    sql: COMMENT ON COLUMN "public"."files"."asset_id" IS E''
+  type: run_sql
+- args:
+    sql: alter table "public"."files" rename column "asset_id" to "assetId";
+  type: run_sql

--- a/hasura/migrations/1580318398743_alter_table_public_files_alter_column_fileobject_id/down.yaml
+++ b/hasura/migrations/1580318398743_alter_table_public_files_alter_column_fileobject_id/down.yaml
@@ -1,0 +1,9 @@
+- args:
+    sql: ALTER TABLE "public"."files" ALTER COLUMN "fileobject_id" TYPE integer;
+  type: run_sql
+- args:
+    sql: COMMENT ON COLUMN "public"."files"."fileobject_id" IS E'null'
+  type: run_sql
+- args:
+    sql: alter table "public"."files" rename column "fileobjectId" to "fileobject_id";
+  type: run_sql

--- a/hasura/migrations/1580318398743_alter_table_public_files_alter_column_fileobject_id/up.yaml
+++ b/hasura/migrations/1580318398743_alter_table_public_files_alter_column_fileobject_id/up.yaml
@@ -1,0 +1,9 @@
+- args:
+    sql: ALTER TABLE "public"."files" ALTER COLUMN "fileobject_id" TYPE int4;
+  type: run_sql
+- args:
+    sql: COMMENT ON COLUMN "public"."files"."fileobject_id" IS E''
+  type: run_sql
+- args:
+    sql: alter table "public"."files" rename column "fileobject_id" to "fileobjectId";
+  type: run_sql

--- a/hasura/migrations/1580318412130_alter_table_public_files_alter_column_uploaded_by_id/down.yaml
+++ b/hasura/migrations/1580318412130_alter_table_public_files_alter_column_uploaded_by_id/down.yaml
@@ -1,0 +1,9 @@
+- args:
+    sql: ALTER TABLE "public"."files" ALTER COLUMN "uploaded_by_id" TYPE integer;
+  type: run_sql
+- args:
+    sql: COMMENT ON COLUMN "public"."files"."uploaded_by_id" IS E'null'
+  type: run_sql
+- args:
+    sql: alter table "public"."files" rename column "uploadedById" to "uploaded_by_id";
+  type: run_sql

--- a/hasura/migrations/1580318412130_alter_table_public_files_alter_column_uploaded_by_id/up.yaml
+++ b/hasura/migrations/1580318412130_alter_table_public_files_alter_column_uploaded_by_id/up.yaml
@@ -1,0 +1,9 @@
+- args:
+    sql: ALTER TABLE "public"."files" ALTER COLUMN "uploaded_by_id" TYPE int4;
+  type: run_sql
+- args:
+    sql: COMMENT ON COLUMN "public"."files"."uploaded_by_id" IS E''
+  type: run_sql
+- args:
+    sql: alter table "public"."files" rename column "uploaded_by_id" to "uploadedById";
+  type: run_sql

--- a/hasura/migrations/1580318438894_set_fk_public_files_fileFormatId/down.yaml
+++ b/hasura/migrations/1580318438894_set_fk_public_files_fileFormatId/down.yaml
@@ -1,0 +1,4 @@
+- args:
+    sql: "\n          alter table \"public\".\"files\" drop constraint \"files_fileFormatId_fkey\"\n
+      \     "
+  type: run_sql

--- a/hasura/migrations/1580318438894_set_fk_public_files_fileFormatId/up.yaml
+++ b/hasura/migrations/1580318438894_set_fk_public_files_fileFormatId/up.yaml
@@ -1,0 +1,6 @@
+- args:
+    sql: "\n           alter table \"public\".\"files\"\n           add constraint
+      \"files_fileFormatId_fkey\"\n           foreign key (\"fileFormatId\")\n           references
+      \"public\".\"fileformats\"\n           (\"id\") on update no action on delete
+      no action;\n      "
+  type: run_sql

--- a/hasura/migrations/1580421893137_delete_fk_public_files_files_fileFormatId_fkey/down.yaml
+++ b/hasura/migrations/1580421893137_delete_fk_public_files_files_fileFormatId_fkey/down.yaml
@@ -1,0 +1,4 @@
+- args:
+    sql: alter table "public"."files" add foreign key ("fileFormatId") references
+      "public"."fileformats"("id") on update no action on delete no action;
+  type: run_sql

--- a/hasura/migrations/1580421893137_delete_fk_public_files_files_fileFormatId_fkey/up.yaml
+++ b/hasura/migrations/1580421893137_delete_fk_public_files_files_fileFormatId_fkey/up.yaml
@@ -1,0 +1,3 @@
+- args:
+    sql: alter table "public"."files" drop constraint "files_fileFormatId_fkey";
+  type: run_sql

--- a/minio/minioconfig
+++ b/minio/minioconfig
@@ -204,7 +204,7 @@
     "webhook": {
       "1": {
         "enable": true,
-        "endpoint": "http://host.docker.internal:8000/webhooks/minio",
+        "endpoint": "http://localhost:8000/webhooks/minio",
         "queueDir": "/events",
         "queueLimit": 10
       }

--- a/server/src/queue/worker.ts
+++ b/server/src/queue/worker.ts
@@ -19,6 +19,6 @@ async function runUnit (params) {
 
 export default async function worker (queue: string = 'main') {
   await boss.connect()
-  console.log('connected')
+  console.log('Worker connected')
   await boss.subscribe(queue, runUnit)
 }

--- a/server/src/routes/upload.ts
+++ b/server/src/routes/upload.ts
@@ -55,6 +55,7 @@ export function routes (app: any, session: any) {
 
   app.post('/webhooks/minio',
     async (req: express.Request, res: express.Response) => {
+      console.log(`Minio webhook`)
       if (!_.isEmpty(req.body)) {
         const fileInfo = req.body.Records[0].s3.object
         await queue('processMinioUpload', fileInfo)

--- a/server/src/routes/upload.ts
+++ b/server/src/routes/upload.ts
@@ -19,43 +19,54 @@ export function routes (app: any, session: any) {
   app.post('/sign-upload',
     session,
     async (req: express.Request, res: express.Response) => {
-      console.log(req.body)
       // Create a file object
-      const response = await adminMutate(
-        `${process.cwd()}/../gql/insertFile.gql`,
-        {
-          name: decodeURIComponent(req.body.filename),
-          uploaded_by_id: req.session.dbId,
-          asset_id: req.body.projectId
-        }
-      )
-
-      // Get the unique id of the upload object and make that the filename
-      const filename = response.returning[0].id
-
-      // Send signed url
-      s3Client.presignedPutObject(
-        'uploads', // Bucket name
-        encodeURIComponent(filename),
-        1000,
-        function (e, presignedUrl) {
-          if (e) return console.log(e)
-          res.json({
-            url: presignedUrl,
-            method: 'put',
-            fields: [],
-            headers: {
-              'content-type': req.body.contentType
+      try {
+        const bucketFound = await s3Client.bucketExists('uploads')
+        const response = await adminMutate(
+          `${process.cwd()}/../gql/insertFile.gql`,
+          {
+            name: decodeURIComponent(req.body.filename),
+            uploadedById: req.session.dbId,
+            assetId: req.body.projectId,
+            fileFormatId: req.body.format
+          }
+        )
+        // Get the unique id of the upload object and make that the filename
+        const filename = response.returning[0].id
+        if (bucketFound) {
+          // Send signed url
+          s3Client.presignedPutObject(
+              'uploads', // Bucket name
+              encodeURIComponent(filename),
+              1000,
+              function (e, presignedUrl) {
+                if (e) return console.log(e)
+                res.json({
+                  url: presignedUrl,
+                  method: 'put',
+                  fields: [],
+                  headers: {
+                    'content-type': req.body.contentType
+                  }
+                })
+              }
+            ) 
+        } else {
+          // TODO(Reda): throw an error to stop the front end uppy upload
+          const responseUpdateFileObject = await adminMutate(
+            `${process.cwd()}/../gql/removeFile.gql`, {
+              fileId: response.returning[0].id
             }
-          })
+          )
         }
-      )
+      } catch (error) {
+        console.log(error)
+      }
     }
   )
 
   app.post('/webhooks/minio',
     async (req: express.Request, res: express.Response) => {
-      console.log(`Minio webhook`)
       if (!_.isEmpty(req.body)) {
         const fileInfo = req.body.Records[0].s3.object
         await queue('processMinioUpload', fileInfo)

--- a/server/src/tasks/processMinioUpload.ts
+++ b/server/src/tasks/processMinioUpload.ts
@@ -68,11 +68,13 @@ async function canAccessAsset (id: number) {
 
 export default async function processMinioUpload (input: object) {
 
+  const fileId = _.toInteger(input['key'])
+
   // Get the file object based on the key
   const response = await adminQuery(
     `${process.cwd()}/../gql/getFile.gql`,
     {
-      id: _.toInteger(input['key'])
+      id: fileId
     }
   )
   const file = response[0]
@@ -113,11 +115,17 @@ export default async function processMinioUpload (input: object) {
     )
     const fileobjectId = response.returning[0].id
 
-    // TODO Update file with fileobject reference
+    const uploadedDatetime = new Date().toISOString()
+
     const responseUpdateFileObject = await adminMutate(
-      `${process.cwd()}/../gql/updateFile.gql`,
-      fileInfo
+      `${process.cwd()}/../gql/updateFile.gql`, {
+        fileId: fileId,
+        fileobjectId: fileobjectId,
+        uploadedDatetime: uploadedDatetime
+      }
     )
+
+    console.log(`File ${fileId} processed`)
   }
 
   // // Remove the original file


### PR DESCRIPTION
The Sanity check will be handled by the GraphQL engine if we try to add a file not in the enum table we will get an error that we catch. (Optional) We can add backend checks before processing an upload

**Changes:**

* Update Minio Docker image version to match the latest Minio Client (Reverted! See Notes).
* Added enum tables with all formats supported by Databrary (Disable for dev purposes).
* Fixed the fileObjectID and uploadedDate fields in files table, when MinIO process the upload.
* Added fileFormat tocolumn to file table.
* Added removeFile: when a new file is created and return the id, if any error happens while MinIO is processing the upload we need to delete the dummy file entry created .
* Renamed files table fields to natch the new naming convention.
* Update files table when the upload file already exists in cas bucket.

**Important Notes:**

* Minioconfig webhook must be the docker0 IP address on Linux system (Only for Linux: in fact any call from a docker container to localhost must use docker0 IP)
* There is breaking changes in MinIO releases, the current minio setup will work only with 2019-10-12T01-39-57Z version (and olders).
* To add the file format restriction, add a foreign key to the files table and change the mutation argument in update_files 

**Missing:**
* Backend Errors handling  (Entire server side)
* Stop Uppy upload processing if there any error in the Backend (sign-upload route)

**Ticket:**
* Closes #37 