### PR TITLE
[WIP] Emails settings management

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,8 @@
 
 WSL=1
 
+UPDATE_EMAIL_WEBHOOK=webhooks/email
+
 # postgres config
 POSTGRES_PORT=5432
 POSTGRES_USER=postgres

--- a/client/package.json
+++ b/client/package.json
@@ -36,6 +36,7 @@
     "node-sass": "^4.13.1",
     "quasar": "^1.8.2",
     "v-runtime-template": "^1.10.0",
+    "validator": "^13.0.0",
     "vue-apollo": "^3.0.2",
     "vue-class-component": "^7.2.2",
     "vue-property-decorator": "^8.3.0",

--- a/client/src/components/settings/settingsEmails.vue
+++ b/client/src/components/settings/settingsEmails.vue
@@ -2,28 +2,16 @@
   <div>
   <div class="text-h4 q-mb-md">Emails</div>
   <q-list bordered separator>
-    <q-item dense>
+    <q-item v-for="(email, index) in emails" :key="email" dense>
       <q-item-section>
-        <div>
-          Ryanmasonjar@gmail.com
-          <q-badge color="blue" align="middle">Primary</q-badge>
+        <div class="q-my-md">
+          {{ email }}
+          <q-badge v-if="isPrimary(index)" color="blue" align="middle">Primary</q-badge>
         </div>
       </q-item-section>
       <q-item-section right >
         <div class="text-right">
-          <q-avatar class="text-red-5" icon="delete"/>
-        </div>
-      </q-item-section>
-    </q-item>
-    <q-item dense>
-      <q-item-section>
-        <div>
-          rytiggy@gmail.com
-        </div>
-      </q-item-section>
-      <q-item-section right >
-        <div class="text-right">
-          <q-avatar class="text-red-5" icon="delete"/>
+          <q-avatar class="text-red-5" v-if="!isPrimary(index)" icon="delete" @click="removeEmail(index)"/>
         </div>
       </q-item-section>
     </q-item>
@@ -31,42 +19,96 @@
   <div class="q-pt-md">
     <b>Add new email:</b>
     <q-input
+      v-model.trim="email"
       outlined
       dense
       label="Email"
       class="q-pb-md"
     >
     <template v-slot:after>
-        <q-btn color="primary" label="Add" />
+      <q-btn  color="primary" label="Add" @click="addEmail" />
     </template>
     </q-input>
   </div>
   <div class="q-pt-md">
     <b>Primary email address</b>
     <div class="text-caption">
-      ryanmasonjar@gmail.com will be used for account-related notifications,
+      {{ primaryEmail }} will be used for account-related notifications,
       any web-based operations (e.g. edits), and can be used for password resets.
     </div>
     <q-select
-      v-model="primaryEmail"
+      v-model="updatePrimaryEmail"
       :options="emails"
       label="Primary email"
     >
     <template v-slot:after>
-        <q-btn color="primary" label="Update" />
+      <q-btn color="primary" label="Update" @click="setPrimaryEmail" />
     </template>
     </q-select>
   </div>
   </div>
 </template>
 <script>
+import gql from 'graphql-tag'
+import { get } from 'vuex-pathify'
+import { isEmail } from 'validator'
+
 export default {
   data () {
     return {
-      primaryEmail: 'ryanmasonjar@gmail.com',
-      emails: [
-        'ryanmasonjar@gmail.com', 'rytiggy@gmail.com'
-      ]
+      primaryEmail: '',
+      updatePrimaryEmail: '',
+      emails: [],
+      email: ''
+    }
+  },
+  computed: {
+    userId: get('app/dbId')
+  },
+  async created () {
+    this.getUserEmails()
+  },
+  methods: {
+    isPrimary: function (index) {
+      return this.emails[index] === this.primaryEmail
+    },
+    setPrimaryEmail: function () {
+      if (this.updatePrimaryEmail !== this.primaryEmail) {
+        this.primaryEmail = this.updatePrimaryEmail
+      }
+    },
+    addEmail: function () {
+      if (this.email.length > 0) {
+        if (!this.emails.includes(this.email) && isEmail(this.email)) {
+          this.emails.push(this.email)
+          this.email = ''
+        }
+      }
+    },
+    removeEmail: function (index) {
+      if (!this.isPrimary(index)) {
+        this.emails.splice(index, 1)
+      }
+    },
+    async getUserEmails () {
+      const result = await this.$apollo.query({
+        query: gql`
+          query GetUserEmails ($userId: Int!) {
+            users(where: {id: {_eq: $userId}}) {
+              emails
+              email_primary
+            }
+          }
+        `,
+        variables: {
+          userId: this.userId
+        }
+      })
+      this.primaryEmail = result.data.users[0].email_primary
+      if (result.data.users[0].emails !== null &&
+        result.data.users[0].emails.length > 0) {
+        this.emails = result.data.users[0].emails
+      }
     }
   }
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8939,6 +8939,11 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+validator@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.0.0.tgz#0fb6c6bb5218ea23d368a8347e6d0f5a70e3bcab"
+  integrity sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA==
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       HASURA_GRAPHQL_ENABLE_CONSOLE: ${HASURA_ENABLE_CONSOLE}
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
       HASURA_GRAPHQL_AUTH_HOOK: http://${DOCKER_HOST_IP}:8000/${HASURA_WEBHOOK}
+      EMAIL_WEBHOOK: http://${DOCKER_HOST_IP}:8000/${UPDATE_EMAIL_WEBHOOK}
 
   minio:
     image: minio/minio:latest

--- a/hasura/migrations/1584995851997_alter_table_public_users_add_column_emails/down.yaml
+++ b/hasura/migrations/1584995851997_alter_table_public_users_add_column_emails/down.yaml
@@ -1,0 +1,3 @@
+- args:
+    sql: ALTER TABLE "public"."users" DROP COLUMN "emails";
+  type: run_sql

--- a/hasura/migrations/1584995851997_alter_table_public_users_add_column_emails/up.yaml
+++ b/hasura/migrations/1584995851997_alter_table_public_users_add_column_emails/up.yaml
@@ -1,0 +1,3 @@
+- args:
+    sql: ALTER TABLE "public"."users" ADD COLUMN "emails" jsonb NOT NULL;
+  type: run_sql

--- a/hasura/migrations/1584995937517_update_permission_user_public_table_users/down.yaml
+++ b/hasura/migrations/1584995937517_update_permission_user_public_table_users/down.yaml
@@ -1,0 +1,6 @@
+- args:
+    role: user
+    table:
+      name: users
+      schema: public
+  type: drop_select_permission

--- a/hasura/migrations/1584995937517_update_permission_user_public_table_users/up.yaml
+++ b/hasura/migrations/1584995937517_update_permission_user_public_table_users/up.yaml
@@ -1,0 +1,18 @@
+- args:
+    permission:
+      allow_aggregations: false
+      columns:
+      - datetime_registered
+      - display_full_name
+      - email_primary
+      - emails
+      - id
+      filter:
+        id:
+          _eq: X-Hasura-User-Id
+      limit: null
+    role: user
+    table:
+      name: users
+      schema: public
+  type: create_select_permission

--- a/hasura/migrations/1584995955783_update_permission_user_public_table_users/down.yaml
+++ b/hasura/migrations/1584995955783_update_permission_user_public_table_users/down.yaml
@@ -1,0 +1,6 @@
+- args:
+    role: user
+    table:
+      name: users
+      schema: public
+  type: drop_update_permission

--- a/hasura/migrations/1584995955783_update_permission_user_public_table_users/up.yaml
+++ b/hasura/migrations/1584995955783_update_permission_user_public_table_users/up.yaml
@@ -1,0 +1,20 @@
+- args:
+    permission:
+      columns:
+      - auth_server_id
+      - datetime_registered
+      - display_full_name
+      - email_primary
+      - emails
+      filter:
+        id:
+          _eq: X-Hasura-User-Id
+      localPresets:
+      - key: ""
+        value: ""
+      set: {}
+    role: user
+    table:
+      name: users
+      schema: public
+  type: create_update_permission

--- a/hasura/migrations/1585060380237_create_trigger_updatePrimaryEmail/down.yaml
+++ b/hasura/migrations/1585060380237_create_trigger_updatePrimaryEmail/down.yaml
@@ -1,0 +1,3 @@
+- args:
+    name: updatePrimaryEmail
+  type: delete_event_trigger

--- a/hasura/migrations/1585060380237_create_trigger_updatePrimaryEmail/up.yaml
+++ b/hasura/migrations/1585060380237_create_trigger_updatePrimaryEmail/up.yaml
@@ -1,0 +1,16 @@
+- args:
+    enable_manual: false
+    headers: []
+    name: updatePrimaryEmail
+    retry_conf:
+      interval_sec: 10
+      num_retries: 0
+      timeout_sec: 60
+    table:
+      name: users
+      schema: public
+    update:
+      columns:
+      - email_primary
+    webhook: http://localhost:8000/webhooks/email
+  type: create_event_trigger

--- a/hasura/migrations/1585060957167_modify_tr_updatePrimaryEmail_webhook/down.yaml
+++ b/hasura/migrations/1585060957167_modify_tr_updatePrimaryEmail_webhook/down.yaml
@@ -1,0 +1,17 @@
+- args:
+    enable_manual: false
+    headers: []
+    name: updatePrimaryEmail
+    replace: true
+    retry_conf:
+      interval_sec: 10
+      num_retries: 0
+      timeout_sec: 60
+    table:
+      name: users
+      schema: public
+    update:
+      columns:
+      - email_primary
+    webhook: http://172.17.0.1:8000/webhooks/email
+  type: create_event_trigger

--- a/hasura/migrations/1585060957167_modify_tr_updatePrimaryEmail_webhook/up.yaml
+++ b/hasura/migrations/1585060957167_modify_tr_updatePrimaryEmail_webhook/up.yaml
@@ -1,0 +1,17 @@
+- args:
+    enable_manual: false
+    headers: []
+    name: updatePrimaryEmail
+    replace: true
+    retry_conf:
+      interval_sec: 10
+      num_retries: 0
+      timeout_sec: 60
+    table:
+      name: users
+      schema: public
+    update:
+      columns:
+      - email_primary
+    webhook_from_env: EMAIL_WEBHOOK
+  type: create_event_trigger

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -61,6 +61,7 @@ app.post('/sign-avatar-upload', uploadController.signAvatarUpload)
 // Webhooks routes
 app.get('/auth/webhook', webhooksController.authWebhook)
 app.post('/webhooks/minio', webhooksController.minioWebhook)
+app.post('/webhooks/email', webhooksController.emailWebhook)
 
 app.use('/', proxy(process.env.APP_URL_PROXY))
 

--- a/server/src/controllers/webhooks.ts
+++ b/server/src/controllers/webhooks.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import queue from '../queue'
 import { Request, Response } from 'express'
-import { logger, getSessionUserId } from '@shared'
+import { logger, getSessionUserId, updateUsersPrimaryEmail } from '@shared'
 import { processAvatarUpload } from '@utils'
 
 export const authWebhook = async (req: Request, res: Response) => {
@@ -33,6 +33,19 @@ export const minioWebhook = async (req: Request, res: Response) => {
       await queue('processMinioUpload', minioObject)
     } else if (minioBucket.name === 'avatars') {
       await processAvatarUpload(minioObject)
+    }
+  }
+  res.send('done')
+}
+
+export const emailWebhook = async (req: Request, res: Response) => {
+  if (!_.isEmpty(req.body)) {
+    try {
+      const authServerId = req.body.event.data.new.auth_server_id
+      const primaryEmail = req.body.event.data.new.email_primary
+      await updateUsersPrimaryEmail(authServerId, primaryEmail)
+    } catch (error) {
+      logger.error(error)
     }
   }
   res.send('done')

--- a/server/src/shared/passport.ts
+++ b/server/src/shared/passport.ts
@@ -39,8 +39,10 @@ passport.use(
       // If the user is null, register the user in the database
       if (user === null) {
         user = await registerUser(
-                profile.id,
-                profile.email)
+          profile.id,
+          profile.email,
+          [profile.email]
+        )
 
         logger.debug(`Registered User ${JSON.stringify(user)}`)
       } else {
@@ -107,7 +109,8 @@ export const registerTestUser = async () => {
 
     user = await registerUser(
       keycloakUser.id,
-      process.env.DUMMY_USER_EMAIL
+      process.env.DUMMY_USER_EMAIL,
+      [process.env.DUMMY_USER_EMAIL]
     )
   }
 }
@@ -122,7 +125,8 @@ export const loginTestUser = async () => {
     if (user === null) {
       user = await registerUser(
         process.env.DUMMY_USER_AUTH_SERVER_ID,
-        process.env.DUMMY_USER_EMAIL
+        process.env.DUMMY_USER_EMAIL,
+        [process.env.DUMMY_USER_EMAIL]
       )
 
       logger.debug(`Registered Dummy User ${JSON.stringify(user)}`)

--- a/server/src/units/registerUser.ts
+++ b/server/src/units/registerUser.ts
@@ -3,26 +3,29 @@ import { gql } from 'apollo-server-express'
 import { logger } from '@shared'
 
 const mutation = gql`
-  mutation registerUser($authServerId: String!, $emailPrimary: String!) {
+  mutation registerUser($authServerId: String!, $emailPrimary: String!, $emails: jsonb!) {
     insert_users(objects: {
       auth_server_id: $authServerId,
       email_primary: $emailPrimary,
+      emails: $emails
     }) {
       returning {
         id
         auth_server_id
         email_primary
         display_full_name
+        emails
       }
     }
   }
 `
-export async function registerUser (authServerId: string, emailPrimary: string) {
+export async function registerUser (authServerId: string, emailPrimary: string, emails: string[]) {
   const response = await client.mutate({
     mutation,
     variables: {
       authServerId,
-      emailPrimary
+      emailPrimary,
+      emails
     }
   })
   if (!response) {


### PR DESCRIPTION
The email management will be done through a JSONB column that contains all the emails used (Primary and Secondary), the user can choose one of the emails as a primary one and therefore update the email_primary field in the users table.
Every update to the email_primrary field will trigger a webhook in the NodeJS backend to update the keycloak user info and request an email verification for the new primary email.
Note that the users will be logged out after changing the primary email and will be asked to verify the new address

**Changes:**
* Added validator dependencies to the front-end
* Added JSON blob columns for emails in the users table.
* Added query and mutations to reflect users inputs.

**Tickets:**
* closes #63 